### PR TITLE
Fixes installation in virtualenvs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 from setuptools.command.install import install
-import site
+from distutils.sysconfig import get_python_lib
 import glob
 import shutil
 
@@ -16,12 +16,13 @@ class CopyLibFile(install):
     """
 
     def run(self):
-        install_dirs = site.getsitepackages()
+        install_dir = get_python_lib()
+
         lib_file = glob.glob(__library_file__)
         assert len(lib_file) == 1 and len(install_dirs) >= 1     
 
         print('copying {} -> {}'.format(lib_file[0], install_dirs[0]))
-        shutil.copy(lib_file[0], install_dirs[0])
+        shutil.copy(lib_file[0], install_dir)
 
 
 


### PR DESCRIPTION
I noticed that the site.getsitepackages() call that the setup.py script
uses is not valid in virtual environments. As such, the following
workaround is implemented. See for instance this other case where it has
been used:
https://github.com/pypa/virtualenv/issues/355#issuecomment-318885792

It worked for me on Ubuntu 17.10 using Python 3.6.3