### PR TITLE
fixes install_dirs not defined error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,10 @@ class CopyLibFile(install):
 
     def run(self):
         install_dir = get_python_lib()
-
         lib_file = glob.glob(__library_file__)
-        assert len(lib_file) == 1 and len(install_dirs) >= 1     
+        assert len(lib_file) == 1 and not install_dir.isspace()
 
-        print('copying {} -> {}'.format(lib_file[0], install_dirs[0]))
+        print('copying {} -> {}'.format(lib_file[0], install_dir))
         shutil.copy(lib_file[0], install_dir)
 
 


### PR DESCRIPTION
change notes: 
> distutils.sysconfig.get_python_lib returns path as string
> update assert statement to check if "install_dir" is valid string
> replace "install_dirs" with "install_dir" in print statement