### PR TITLE
replacing _window with self.window in PangolinNSGLView.mm

### DIFF
--- a/src/display/device/PangolinNSGLView.mm
+++ b/src/display/device/PangolinNSGLView.mm
@@ -72,8 +72,8 @@ int mapKeymap(int osx_key)
 -(void)reshape
 {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
-    if ( [self wantsBestResolutionOpenGLSurface] && [ _window respondsToSelector:@selector(backingScaleFactor) ] )
-        backing_scale = [_window backingScaleFactor];
+    if ( [self wantsBestResolutionOpenGLSurface] && [ self.window respondsToSelector:@selector(backingScaleFactor) ] )
+        backing_scale = [self.window backingScaleFactor];
     else
 #endif
         backing_scale = 1.0;


### PR DESCRIPTION
compiling under macOS Big Sur with Xcode 12 cause the following error:

```
      'wantsBestResolutionOpenGLSurface' has been explicitly marked deprecated here
PangolinNSGLView.mm:75:55: error: use of undeclared identifier '_window'
    if ( [self wantsBestResolutionOpenGLSurface] && [ _window respondsToSelector:@selector(backingScaleFactor) ] )
                                                      ^
PangolinNSGLView.mm:76:26: error: use of undeclared identifier '_window'
        backing_scale = [_window backingScaleFactor];
                         ^
```

Replacing `_window` with `self.window` in `src/display/device/PangolinNSGLView.mm` to fix the issue,
