### PR TITLE
Correct the "install_dir" variable name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ class CopyLibFile(install):
         install_dir = get_python_lib()
 
         lib_file = glob.glob(__library_file__)
-        assert len(lib_file) == 1 and len(install_dirs) >= 1     
+        assert len(lib_file) == 1 and len(install_dir) >= 1     
 
-        print('copying {} -> {}'.format(lib_file[0], install_dirs[0]))
+        print('copying {} -> {}'.format(lib_file[0], install_dir[0]))
         shutil.copy(lib_file[0], install_dir)
 
 


### PR DESCRIPTION
Seems like the "install_dir" variable is called as "install_dirs" in the assert and the next print. I was getting an error while trying to install this module. After debugging, found these two corrections. Now able to install the module without a problem